### PR TITLE
fix: restructure RPC Provider section + code focus snippets

### DIFF
--- a/vocs/docs/pages/rpc-providers/http-provider.md
+++ b/vocs/docs/pages/rpc-providers/http-provider.md
@@ -9,7 +9,7 @@ The recommended way of initializing a `Http` provider is by using the [`connect_
 ```rust
 //! Example of creating an HTTP provider using the `connect_http` method on the `ProviderBuilder`.
 
-use alloy::providers::{Provider, ProviderBuilder};
+use alloy::providers::{Provider, ProviderBuilder}; // [!code focus]
 use std::error::Error;
 
 #[tokio::main]
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc".parse()?;
 
     // Create a provider with the HTTP transport using the `reqwest` crate.
-    let provider = ProviderBuilder::new().connect_http(rpc_url);
+    let provider = ProviderBuilder::new().connect_http(rpc_url); // [!code focus]
 
     Ok(())
 }

--- a/vocs/docs/pages/rpc-providers/introduction.md
+++ b/vocs/docs/pages/rpc-providers/introduction.md
@@ -2,7 +2,7 @@
 
 A [`Provider`](https://docs.rs/alloy/latest/alloy/providers/trait.Provider.html) is an abstraction of a connection to the Ethereum network, providing a concise, consistent interface to standard Ethereum node functionality.
 
-### Provider Builder
+### Provider Builder Pattern
 
 The correct way of creating a [`Provider`](https://docs.rs/alloy/latest/alloy/providers/trait.Provider.html) is through the [`ProviderBuilder`](https://docs.rs/alloy/latest/alloy/providers/struct.ProviderBuilder.html), a [builder](https://rust-unofficial.github.io/patterns/patterns/creational/builder.html).
 

--- a/vocs/docs/pages/rpc-providers/ipc-provider.md
+++ b/vocs/docs/pages/rpc-providers/ipc-provider.md
@@ -11,7 +11,7 @@ The recommended way of initializing an `Ipc` provider is by using the [`connect_
 ```rust
 //! Example of creating an IPC provider using the `connect_ipc` method on the `ProviderBuilder`.
 
-use alloy::providers::{IpcConnect, Provider, ProviderBuilder};
+use alloy::providers::{IpcConnect, Provider, ProviderBuilder}; // [!code focus]
 use std::error::Error;
 
 #[tokio::main]
@@ -20,8 +20,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let ipc_path = "/tmp/reth.ipc";
 
     // Create the provider.
-    let ipc = IpcConnect::new(ipc_path.to_string());
-    let provider = ProviderBuilder::new().connect_ipc(ipc).await?;
+    let ipc = IpcConnect::new(ipc_path.to_string()); // [!code focus]
+    let provider = ProviderBuilder::new().connect_ipc(ipc).await?; // [!code focus]
 
     Ok(())
 }

--- a/vocs/docs/pages/rpc-providers/setting-up-a-provider.md
+++ b/vocs/docs/pages/rpc-providers/setting-up-a-provider.md
@@ -1,8 +1,8 @@
-## Setting up a Provider
+## RPC Provider
 
 A [`Provider`](https://docs.rs/alloy/latest/alloy/providers/trait.Provider.html) is an abstraction of a connection to the Ethereum network, providing a concise, consistent interface to standard Ethereum node functionality.
 
-### Builder
+### Provider Builder
 
 The correct way of creating a [`Provider`](https://docs.rs/alloy/latest/alloy/providers/trait.Provider.html) is through the [`ProviderBuilder`](https://docs.rs/alloy/latest/alloy/providers/struct.ProviderBuilder.html), a [builder](https://rust-unofficial.github.io/patterns/patterns/creational/builder.html).
 
@@ -10,19 +10,18 @@ Alloy provides concrete transport implementations for [`HTTP`](/rpc-providers/ht
 
 The [`connect`](https://docs.rs/alloy/latest/alloy/providers/struct.ProviderBuilder.html#method.connect) method on the [`ProviderBuilder`](https://docs.rs/alloy/latest/alloy/providers/struct.ProviderBuilder.html) will automatically determine the connection type (`Http`, `Ws` or `Ipc`) depending on the format of the URL.
 
-```rust
-//! Example of `.connect` to setup a simple provider
+```rust showLineNumbers
+//! Example of setting up a provider using the `.connect` method.
 
-use alloy::providers::{Provider, ProviderBuilder};
+use alloy::providers::{Provider, ProviderBuilder}; // [!code focus]
 use std::error::Error;
 
+const RPC_URL: &str = "https://reth-ethereum.ithaca.xyz/rpc";
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    // Set up the RPC URL.
-    let rpc_url = "https://reth-ethereum.ithaca.xyz/rpc";
 
-    // Instanties a provider using a rpc_url string.
-    let provider = ProviderBuilder::new().connect(rpc_url).await?;
+    // Instanties a provider using a string.
+    let provider = ProviderBuilder::new().connect(RPC_URL).await?; // [!code focus]
 
     Ok(())
 }

--- a/vocs/docs/pages/rpc-providers/ws-provider.md
+++ b/vocs/docs/pages/rpc-providers/ws-provider.md
@@ -9,7 +9,7 @@ The recommended way of initializing a `Ws` provider is by using the [`connect_ws
 ```rust
 //! Example of creating an WS provider using the `connect_ws` method on the `ProviderBuilder`.
 
-use alloy::providers::{Provider, ProviderBuilder, WsConnect};
+use alloy::providers::{Provider, ProviderBuilder, WsConnect}; // [!code focus]
 use std::error::Error;
 
 #[tokio::main]
@@ -18,8 +18,8 @@ async fn main() -> eyre::Result<(), Box<dyn Error>> {
     let rpc_url = "wss://eth-mainnet.g.alchemy.com/v2/your-api-key";
 
     // Create the provider.
-    let ws = WsConnect::new(rpc_url);
-    let provider = ProviderBuilder::new().connect_ws(ws).await?;
+    let ws = WsConnect::new(rpc_url); // [!code focus]
+    let provider = ProviderBuilder::new().connect_ws(ws).await?; // [!code focus]
 
     Ok(())
 }

--- a/vocs/docs/pages/transactions/transaction-lifecycle.md
+++ b/vocs/docs/pages/transactions/transaction-lifecycle.md
@@ -76,7 +76,7 @@ The `RecommendedFillers` includes the following fillers:
 - [NonceFiller](https://docs.rs/alloy/latest/alloy/providers/fillers/struct.NonceFiller.html)
 - [ChainIdFiller](https://docs.rs/alloy/latest/alloy/providers/fillers/struct.ChainIdFiller.html)
 
-Because of we are using `RecommendedFillers` our `TransactionRequest` we only need a subset of the original fields:
+Because we are using `RecommendedFillers` for filling the `TransactionRequest` we only need a subset of the original fields:
 
 ```diff showLineNumbers
 // Build a transaction to send 100 wei from Alice to Bob.

--- a/vocs/docs/pages/transactions/transaction-lifecycle.md
+++ b/vocs/docs/pages/transactions/transaction-lifecycle.md
@@ -65,7 +65,7 @@ let provider = ProviderBuilder::new()
     .connect_http(rpc_url);
 ```
 
-Note that the [ProviderBuilder](/rpc-providers/setting-up-a-provider.md) constructor `new` initializes the [RecommendedFillers](/rpc-providers/understanding-fillers).
+Note that the [ProviderBuilder](/rpc-providers/introduction) constructor `new` initializes the [RecommendedFillers](/rpc-providers/understanding-fillers).
 
 Let's modify our original `TransactionRequest` to make use of the [RecommendedFiller](https://docs.rs/alloy/latest/alloy/providers/fillers/type.RecommendedFiller.html) installed on the `Provider` to automatically fill out transaction details.
 

--- a/vocs/sidebar.ts
+++ b/vocs/sidebar.ts
@@ -25,8 +25,8 @@ export const sidebar: Sidebar = [
     },
     { 
       text: 'RPC Providers', 
+      link: '/rpc-providers/setting-up-a-provider',
       items: [
-      { text: 'Setting up a provider', link: '/rpc-providers/setting-up-a-provider' },
       { text: 'HTTP provider', link: '/rpc-providers/http-provider' },
       { text: 'WS provider', link: '/rpc-providers/ws-provider' },
       { text: 'IPC provider', link: '/rpc-providers/ipc-provider' },

--- a/vocs/sidebar.ts
+++ b/vocs/sidebar.ts
@@ -25,8 +25,8 @@ export const sidebar: Sidebar = [
     },
     { 
       text: 'RPC Providers', 
-      link: '/rpc-providers/setting-up-a-provider',
       items: [
+      { text: 'Introduction', link: '/rpc-providers/introduction' },
       { text: 'HTTP provider', link: '/rpc-providers/http-provider' },
       { text: 'WS provider', link: '/rpc-providers/ws-provider' },
       { text: 'IPC provider', link: '/rpc-providers/ipc-provider' },


### PR DESCRIPTION
The "Setting up a provider" page felt redundant.

Basic introduction and provider setup is now merged into Section Page i.e RPC Provider

Also added code focus to provider setup snippets