### PR TITLE
fix: update ethereum JSON RPC docs link

### DIFF
--- a/vocs/docs/pages/index.mdx
+++ b/vocs/docs/pages/index.mdx
@@ -372,7 +372,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 Alloy supports the following out of the box for a best-in-class developer experience:
 
-- Fully [Ethereum JSON-RPC](https://ethereum.github.io/execution-apis/api-documentation/) compliant along with support for `trace`, `debug` and `anvil` endpoints
+- Fully [Ethereum JSON-RPC](https://ethereum.github.io/execution-apis/docs/reference/json-rpc-api) compliant along with support for `trace`, `debug` and `anvil` endpoints
 - Seamless contract interactions using the [`sol!`](/contract-interactions/using-sol!) macro
 - Highly performant [core primitives](https://github.com/alloy-rs/core) such as `U256` Operations and ABI encoding
 - Override / extend provider and transport behavior using [layers](/examples/layers/README) and [fillers](/rpc-providers/understanding-fillers) akin to [Tower](https://docs.rs/tower/latest/tower/)'s [layers](https://docs.rs/tower/latest/tower/trait.Layer.html)


### PR DESCRIPTION
plus, these links are invalid but I'm not sure what each should point to:

- https://alloy.rs/highlights/the-sol!-procedural-macro.html
- https://github.com/foundry-rs/foundry/tree/master/crates/common/src/ens.rs
- https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types/src/eth
- https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types/src/eth/account.rs
- https://github.com/alloy-rs/alloy/tree/main/crates/rpc-types/src/eth/transaction/signature.rs