### PR TITLE
docs: fix eip7702 description

### DIFF
--- a/vocs/docs/pages/transactions/sending-an-EIP-7702-transaction.md
+++ b/vocs/docs/pages/transactions/sending-an-EIP-7702-transaction.md
@@ -4,7 +4,7 @@ description: Send EIP-7702 transactions with authorization lists for account abs
 
 ## Sending an EIP-7702 transaction
 
-Send an [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) transaction by specifying the `authorization_list` field. This is also known as a blob transaction.
+Send an [EIP-7702](https://eips.ethereum.org/EIPS/eip-7702) transaction by specifying the `authorization_list` field. This is also known as a set code transaction.
 
 ```rust
 // [!include ~/snippets/transactions/examples/send_eip7702_transaction.rs]


### PR DESCRIPTION
Fixes the description for the EIP7702 example in the alloy docs from "blob transaction" to "set code transaction".